### PR TITLE
Avoid cache key collition

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,7 @@ APP_LOGO=
 APP_ADDRESS=localhost:3000
 APP_DOMAIN=https://localhost
 APP_CORS_ORIGINS=
+APP_KEY=
 
 DB_HOST=localhost
 DB_PORT=5432

--- a/internal/controllers/auth.go
+++ b/internal/controllers/auth.go
@@ -219,7 +219,7 @@ func AuthRefresh(c *fiber.Ctx) error {
 		})
 	}
 
-	isRefreshRevoked, err := app.Cache().DoCache(context.Background(), app.Cache().B().Sismember().Key("refresh-tokens:revoked").Member(refreshJWEClaims.ID).Cache(), 5*time.Minute).AsBool()
+	isRefreshRevoked, err := app.Cache().DoCache(context.Background(), app.Cache().B().Sismember().Key(utils.CacheKey("refresh-tokens:revoked")).Member(refreshJWEClaims.ID).Cache(), 5*time.Minute).AsBool()
 	if err != nil && !errors.Is(err, valkey.Nil) {
 		sentry.CaptureException(err)
 		slog.Error(fmt.Sprintf("Could not check token revocation '%s': %v", refreshJWEClaims.ID, err))
@@ -291,8 +291,8 @@ func AuthRefresh(c *fiber.Ctx) error {
 
 	errs := []error{}
 	cmds := valkey.Commands{
-		app.Cache().B().Sadd().Key("access-tokens:revoked").Member(accessJWEClaims.ID).Build(),
-		app.Cache().B().Sadd().Key("refresh-tokens:revoked").Member(refreshJWEClaims.ID).Build(),
+		app.Cache().B().Sadd().Key(utils.CacheKey("access-tokens:revoked")).Member(accessJWEClaims.ID).Build(),
+		app.Cache().B().Sadd().Key(utils.CacheKey("refresh-tokens:revoked")).Member(refreshJWEClaims.ID).Build(),
 	}
 
 	for _, res := range app.Cache().DoMulti(context.Background(), cmds...) {
@@ -656,8 +656,8 @@ func AuthLogout(c *fiber.Ctx) error {
 
 	errs := []error{}
 	cmds := valkey.Commands{
-		app.Cache().B().Sadd().Key("access-tokens:revoked").Member(accessJWEClaims.ID).Build(),
-		app.Cache().B().Sadd().Key("refresh-tokens:revoked").Member(refreshJWEClaims.ID).Build(),
+		app.Cache().B().Sadd().Key(utils.CacheKey("access-tokens:revoked")).Member(accessJWEClaims.ID).Build(),
+		app.Cache().B().Sadd().Key(utils.CacheKey("refresh-tokens:revoked")).Member(refreshJWEClaims.ID).Build(),
 	}
 
 	for _, res := range app.Cache().DoMulti(context.Background(), cmds...) {

--- a/internal/controllers/system.go
+++ b/internal/controllers/system.go
@@ -8,6 +8,7 @@ import (
 
 	"alfredoramos.mx/csp-reporter/internal/app"
 	"alfredoramos.mx/csp-reporter/internal/tasks"
+	"alfredoramos.mx/csp-reporter/internal/utils"
 	"github.com/getsentry/sentry-go"
 	"github.com/gofiber/fiber/v2"
 	"github.com/valkey-io/valkey-go"
@@ -27,7 +28,7 @@ func PurgeCache(c *fiber.Ctx) error {
 	// ! Do not purge tokens
 	errs := []error{}
 	cmds := valkey.Commands{
-		app.Cache().B().Del().Key("email:superadmin:list").Build(),
+		app.Cache().B().Del().Key(utils.CacheKey("email:superadmin:list")).Build(),
 	}
 
 	for _, res := range app.Cache().DoMulti(context.Background(), cmds...) {

--- a/internal/helpers/cache.go
+++ b/internal/helpers/cache.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"alfredoramos.mx/csp-reporter/internal/app"
+	"alfredoramos.mx/csp-reporter/internal/utils"
 	"github.com/getsentry/sentry-go"
 	"github.com/valkey-io/valkey-go"
 )
@@ -17,6 +18,8 @@ const (
 )
 
 func PurgeCachePattern(pattern string) error {
+	pattern = utils.CacheKey(pattern)
+
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 	cursor := uint64(0)
@@ -25,7 +28,7 @@ func PurgeCachePattern(pattern string) error {
 		select {
 		case <-ctx.Done():
 			slog.Warn(fmt.Sprintf("Cache purge timeout: %v", ctx.Err()))
-			break
+			return ctx.Err()
 		default:
 			// Continue
 		}
@@ -40,12 +43,7 @@ func PurgeCachePattern(pattern string) error {
 		cursor = result.Cursor
 
 		for i := 0; i < len(result.Elements); i += int(batchSize) {
-			end := i + int(batchSize)
-
-			if end > len(result.Elements) {
-				end = len(result.Elements)
-			}
-
+			end := min(i+int(batchSize), len(result.Elements))
 			batch := result.Elements[i:end]
 
 			cmds := make(valkey.Commands, 0, len(batch))

--- a/internal/helpers/domain.go
+++ b/internal/helpers/domain.go
@@ -24,7 +24,8 @@ func IsAllowedDomain(d string) bool {
 		return false
 	}
 
-	cachedDomain, err := app.Cache().DoCache(context.Background(), app.Cache().B().Get().Key(fmt.Sprintf("domain:%s", domain)).Cache(), 5*time.Minute).ToString()
+	cacheKey := utils.CacheKey(fmt.Sprintf("domain:%s", domain))
+	cachedDomain, err := app.Cache().DoCache(context.Background(), app.Cache().B().Get().Key(cacheKey).Cache(), 5*time.Minute).ToString()
 	if err != nil && !errors.Is(err, valkey.Nil) {
 		sentry.CaptureException(err)
 		slog.Warn(fmt.Sprintf("Could not get cached domain: %v", err))
@@ -49,7 +50,7 @@ func IsAllowedDomain(d string) bool {
 	}
 
 	if utils.IsValidUuid(site.ID) {
-		if err := app.Cache().Do(context.Background(), app.Cache().B().Set().Key(fmt.Sprintf("domain:%s", domain)).Value(site.ID.String()).Ex(time.Hour).Build()).Error(); err != nil {
+		if err := app.Cache().Do(context.Background(), app.Cache().B().Set().Key(cacheKey).Value(site.ID.String()).Ex(time.Hour).Build()).Error(); err != nil {
 			sentry.CaptureException(err)
 			slog.Error(fmt.Sprintf("Could not save user to cache: %v", err))
 		}

--- a/internal/helpers/email.go
+++ b/internal/helpers/email.go
@@ -215,7 +215,8 @@ func GetSuperAdminEmails() []string {
 	e := []string{}
 
 	// Try to load from cache
-	ce, err := app.Cache().DoCache(context.Background(), app.Cache().B().Get().Key("email:superadmin:list").Cache(), 5*time.Minute).ToString()
+	cacheKey := utils.CacheKey("email:superadmin:list")
+	ce, err := app.Cache().DoCache(context.Background(), app.Cache().B().Get().Key(cacheKey).Cache(), 5*time.Minute).ToString()
 	if err != nil && !errors.Is(err, valkey.Nil) {
 		sentry.CaptureException(err)
 		slog.Warn(fmt.Sprintf("Could not get cached superadministrator email list: %v", err))
@@ -238,14 +239,16 @@ func GetSuperAdminEmails() []string {
 		slog.Error(fmt.Sprintf("Could not get superadministrator emails: %v", err))
 	}
 
-	re, err := json.Marshal(e)
-	if err != nil {
-		slog.Error(fmt.Sprintf("Could not serialize superadministrator email list for cache: %v", err))
-	}
+	if len(e) > 0 {
+		re, err := json.Marshal(e)
+		if err != nil {
+			slog.Error(fmt.Sprintf("Could not serialize superadministrator email list for cache: %v", err))
+		}
 
-	if err := app.Cache().Do(context.Background(), app.Cache().B().Set().Key("email:superadmin:list").Value(string(re)).Ex(15*time.Minute).Build()).Error(); err != nil {
-		sentry.CaptureException(err)
-		slog.Error(fmt.Sprintf("Could not save superadministrator email list to cache: %v", err))
+		if err := app.Cache().Do(context.Background(), app.Cache().B().Set().Key(cacheKey).Value(string(re)).Ex(15*time.Minute).Build()).Error(); err != nil {
+			sentry.CaptureException(err)
+			slog.Error(fmt.Sprintf("Could not save superadministrator email list to cache: %v", err))
+		}
 	}
 
 	return e

--- a/internal/helpers/role.go
+++ b/internal/helpers/role.go
@@ -51,7 +51,8 @@ func GetUserRoles(id uuid.UUID) (userRoleList, error) {
 
 	roles := []userRole{}
 
-	cachedRoles, err := app.Cache().DoCache(context.Background(), app.Cache().B().Get().Key(fmt.Sprintf("roles:%s", id.String())).Cache(), 5*time.Minute).ToString()
+	cacheKey := utils.CacheKey(fmt.Sprintf("roles:%s", id.String()))
+	cachedRoles, err := app.Cache().DoCache(context.Background(), app.Cache().B().Get().Key(cacheKey).Cache(), 5*time.Minute).ToString()
 	if err != nil && !errors.Is(err, valkey.Nil) {
 		sentry.CaptureException(err)
 		slog.Warn(fmt.Sprintf("Could not get cached roles: %v", err))
@@ -82,7 +83,7 @@ func GetUserRoles(id uuid.UUID) (userRoleList, error) {
 			slog.Error(fmt.Sprintf("Could not serialize roles for cache: %v", err))
 		}
 
-		if err := app.Cache().Do(context.Background(), app.Cache().B().Set().Key(fmt.Sprintf("roles:%s", id.String())).Value(string(rawRoles)).Ex(24*time.Hour).Build()).Error(); err != nil {
+		if err := app.Cache().Do(context.Background(), app.Cache().B().Set().Key(cacheKey).Value(string(rawRoles)).Ex(24*time.Hour).Build()).Error(); err != nil {
 			sentry.CaptureException(err)
 			slog.Error(fmt.Sprintf("Could not save roles to cache: %v", err))
 		}
@@ -106,10 +107,10 @@ func HasPermission(id uuid.UUID, p string, m string) bool {
 		return false
 	}
 
-	ps := [][]interface{}{}
+	ps := [][]any{}
 
 	for _, val := range r.Names() {
-		ps = append(ps, []interface{}{val, p, m})
+		ps = append(ps, []any{val, p, m})
 	}
 
 	result, err := app.Auth().BatchEnforce(ps)

--- a/internal/helpers/user.go
+++ b/internal/helpers/user.go
@@ -21,7 +21,8 @@ func UserExists(id uuid.UUID, email string) bool {
 		return false
 	}
 
-	cachedUser, err := app.Cache().DoCache(context.Background(), app.Cache().B().Get().Key(fmt.Sprintf("user:%s", id.String())).Cache(), 5*time.Minute).ToString()
+	cacheKey := utils.CacheKey(fmt.Sprintf("user:%s", id.String()))
+	cachedUser, err := app.Cache().DoCache(context.Background(), app.Cache().B().Get().Key(cacheKey).Cache(), 5*time.Minute).ToString()
 	if err != nil && !errors.Is(err, valkey.Nil) {
 		sentry.CaptureException(err)
 		slog.Warn(fmt.Sprintf("Could not get cached user: %v", err))
@@ -37,7 +38,7 @@ func UserExists(id uuid.UUID, email string) bool {
 	}
 
 	if utils.IsValidUuid(user.ID) {
-		if err := app.Cache().Do(context.Background(), app.Cache().B().Set().Key(fmt.Sprintf("user:%s", id.String())).Value(user.Email).Ex(time.Hour).Build()).Error(); err != nil {
+		if err := app.Cache().Do(context.Background(), app.Cache().B().Set().Key(cacheKey).Value(user.Email).Ex(time.Hour).Build()).Error(); err != nil {
 			sentry.CaptureException(err)
 			slog.Error(fmt.Sprintf("Could not save user to cache: %v", err))
 		}

--- a/internal/middlewares/auth.go
+++ b/internal/middlewares/auth.go
@@ -108,7 +108,7 @@ func ValidateAccessToken() fiber.Handler {
 			return jwtError(c, fiber.StatusUnauthorized, fmt.Errorf("invalid access token issuer: %v", accessClaims.Issuer))
 		}
 
-		isAccessRevoked, err := app.Cache().DoCache(context.Background(), app.Cache().B().Sismember().Key("access-tokens:revoked").Member(accessClaims.ID).Cache(), 5*time.Minute).AsBool()
+		isAccessRevoked, err := app.Cache().DoCache(context.Background(), app.Cache().B().Sismember().Key(utils.CacheKey("access-tokens:revoked")).Member(accessClaims.ID).Cache(), 5*time.Minute).AsBool()
 		if err != nil && !errors.Is(err, valkey.Nil) {
 			return jwtError(c, fiber.StatusUnauthorized, fmt.Errorf("could not check token revocation '%v': %w", accessClaims.ID, err))
 		}
@@ -177,7 +177,7 @@ func ValidateRefreshToken() fiber.Handler {
 			return jwtError(c, fiber.StatusUnauthorized, fmt.Errorf("invalid access token issuer: %v", accessClaims.Issuer))
 		}
 
-		isAccessRevoked, err := app.Cache().DoCache(context.Background(), app.Cache().B().Sismember().Key("access-tokens:revoked").Member(accessClaims.ID).Cache(), 5*time.Minute).AsBool()
+		isAccessRevoked, err := app.Cache().DoCache(context.Background(), app.Cache().B().Sismember().Key(utils.CacheKey("access-tokens:revoked")).Member(accessClaims.ID).Cache(), 5*time.Minute).AsBool()
 		if err != nil && !errors.Is(err, valkey.Nil) {
 			return jwtError(c, fiber.StatusUnauthorized, fmt.Errorf("could not check token revocation '%v': %w", accessClaims.ID, err))
 		}
@@ -200,7 +200,7 @@ func ValidateRefreshToken() fiber.Handler {
 			return jwtError(c, fiber.StatusUnauthorized, fmt.Errorf("invalid refresh token issuer: %v", refreshClaims.Issuer))
 		}
 
-		isRefreshRevoked, err := app.Cache().DoCache(context.Background(), app.Cache().B().Sismember().Key("refresh-tokens:revoked").Member(refreshClaims.ID).Cache(), 5*time.Minute).AsBool()
+		isRefreshRevoked, err := app.Cache().DoCache(context.Background(), app.Cache().B().Sismember().Key(utils.CacheKey("refresh-tokens:revoked")).Member(refreshClaims.ID).Cache(), 5*time.Minute).AsBool()
 		if err != nil && !errors.Is(err, valkey.Nil) {
 			return jwtError(c, fiber.StatusUnauthorized, fmt.Errorf("could not check token revocation '%v': %w", refreshClaims.ID, err))
 		}

--- a/internal/utils/cache.go
+++ b/internal/utils/cache.go
@@ -1,0 +1,66 @@
+package utils
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+
+	"github.com/getsentry/sentry-go"
+	"golang.org/x/crypto/blake2s"
+)
+
+func Blake2s128Hash(input string, key []byte) (string, error) {
+	if len(key) < 1 {
+		err := errors.New("invalid key")
+		sentry.CaptureException(err)
+		return "", err
+	}
+
+	if len(key) > blake2s.Size {
+		slog.Warn(fmt.Sprintf("Key is too long, truncating to %d bytes", blake2s.Size))
+		key = key[:blake2s.Size]
+	}
+
+	hash, err := blake2s.New128(key)
+	if err != nil {
+		sentry.CaptureException(err)
+		return "", err
+	}
+
+	hash.Write([]byte(input))
+	sum := hash.Sum(nil)
+
+	return hex.EncodeToString(sum), nil
+}
+
+func CacheKey(key string) string {
+	key = strings.TrimSpace(key)
+
+	if len(key) < 1 {
+		return ""
+	}
+
+	appName := os.Getenv("APP_NAME")
+	appEnv := AppEnv()
+
+	prefix, err := Blake2s128Hash(appName, AppKey())
+	if err != nil {
+		sentry.CaptureException(err)
+		slog.Error("Error generating cache key prefix", "error", err)
+		return key
+	}
+
+	if !IsProduction() {
+		prefix += ":" + appEnv
+	}
+
+	if strings.HasPrefix(key, prefix) {
+		slog.Warn(fmt.Sprintf("Cache key '%s' already has prefix '%s'", key, prefix))
+		return key
+	}
+
+	return prefix + ":" + key
+}

--- a/internal/utils/env.go
+++ b/internal/utils/env.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -26,6 +27,18 @@ const (
 	ProductionEnv  string = "production"
 	DevelopmentEnv string = "development"
 )
+
+func AppKey() []byte {
+	key := strings.TrimSpace(os.Getenv("APP_KEY"))
+
+	if len(key) < 1 {
+		err := errors.New("invalid application key")
+		sentry.CaptureException(err)
+		panic(err.Error())
+	}
+
+	return []byte(key)
+}
 
 func AppEnv() string {
 	e := strings.TrimSpace(os.Getenv("APP_ENV"))


### PR DESCRIPTION
Prefix cache keys with a hash calculated using `blake2s` (128 bits) on the application name.

It introduces the requirement of a 512-bit application key that will be used for cryptographic actions.