### PR TITLE
Update minimum Go version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.24.5'
+          go-version: '^1.24.6'
 
       - name: Install dependencies
         run: go mod tidy
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.24.5'
+          go-version: '^1.24.6'
 
       - name: Install dependencies
         run: go mod tidy
@@ -72,7 +72,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.24.5'
+          go-version: '^1.24.6'
 
       - name: Install utils
         run: make utils

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Backend for the **CSP Reporter** REST API using [Fiber](https://gofiber.io), [GO
 
 ## Requirements
 
-- [Go](https://go.dev/dl/) >= 1.24.5
+- [Go](https://go.dev/dl/) >= 1.24.6
 - [PostgreSQL](https://www.postgresql.org/download/) >= 17.2
 - [Valkey](https://valkey.io/download/) >= 8.1
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module alfredoramos.mx/csp-reporter
 
-go 1.24.5
+go 1.24.6
 
 require (
 	github.com/BurntSushi/toml v1.5.0


### PR DESCRIPTION
Fix for [GO-2025-3849](https://pkg.go.dev/vuln/GO-2025-3849) / [CVE-2025-47907](https://www.cve.org/CVERecord?id=CVE-2025-47907).