### PR TITLE
Remove cache keys in logs

### DIFF
--- a/internal/cache/prefix.go
+++ b/internal/cache/prefix.go
@@ -75,3 +75,29 @@ func Key(key string) string {
 
 	return prefix + ":" + key
 }
+
+func RemoveKey(key string) string {
+	key = strings.TrimSpace(key)
+
+	if len(key) < 1 {
+		return ""
+	}
+
+	prefix, err := Prefix()
+	if err != nil {
+		sentry.CaptureException(err)
+		slog.Error("Error generating cache key prefix", slog.Any("error", err))
+		return key
+	}
+
+	if !strings.HasPrefix(key, prefix) {
+		slog.Warn(
+			"Cache key does not include the prefix",
+			slog.String("key", key),
+			slog.String("prefix", prefix),
+		)
+		return key
+	}
+
+	return strings.Replace(key, prefix+":", "", 1)
+}

--- a/internal/tasks/cache.go
+++ b/internal/tasks/cache.go
@@ -28,7 +28,7 @@ func NewPurgeCachePatternTask(p string) (*asynq.Task, error) {
 		return nil, err
 	}
 
-	return asynq.NewTask(TaskPurgeCachePattern, payload), nil
+	return asynq.NewTask(cache.Key(TaskPurgeCachePattern), payload), nil
 }
 
 func HandlePurgeCachePatternTask(ctx context.Context, t *asynq.Task) error { //nolint:unused
@@ -64,7 +64,7 @@ func NewPurgeCachePattern(p string) error {
 	slog.Info(
 		"Enqueued",
 		slog.String("task-id", info.ID),
-		slog.String("queue", info.Queue),
+		slog.String("queue", cache.RemoveKey(info.Queue)),
 	)
 
 	return nil

--- a/internal/tasks/csp.go
+++ b/internal/tasks/csp.go
@@ -28,7 +28,7 @@ func NewReportAddTask(d helpers.CspReport) (*asynq.Task, error) {
 		return nil, err
 	}
 
-	return asynq.NewTask(TaskReportAdd, payload), nil
+	return asynq.NewTask(cache.Key(TaskReportAdd), payload), nil
 }
 
 func HandleReportAddTask(ctx context.Context, t *asynq.Task) error { //nolint:unused
@@ -64,7 +64,7 @@ func NewCspReport(d helpers.CspReport) error {
 	slog.Info(
 		"Enqueued",
 		slog.String("task-id", info.ID),
-		slog.String("queue", info.Queue),
+		slog.String("queue", cache.RemoveKey(info.Queue)),
 	)
 
 	return nil

--- a/internal/tasks/email.go
+++ b/internal/tasks/email.go
@@ -30,7 +30,7 @@ func NewEmailDeliveryTask(o *helpers.EmailOpts, d map[string]any) (*asynq.Task, 
 		return nil, err
 	}
 
-	return asynq.NewTask(TaskEmailDelivery, payload), nil
+	return asynq.NewTask(cache.Key(TaskEmailDelivery), payload), nil
 }
 
 func HandleEmailDeliveryTask(ctx context.Context, t *asynq.Task) error { //nolint:unused
@@ -67,7 +67,7 @@ func NewEmail(o *helpers.EmailOpts, d map[string]any) error {
 	slog.Info(
 		"Enqueued",
 		slog.String("task-id", info.ID),
-		slog.String("queue", info.Queue),
+		slog.String("queue", cache.RemoveKey(info.Queue)),
 	)
 
 	return nil

--- a/internal/tasks/setup.go
+++ b/internal/tasks/setup.go
@@ -64,9 +64,9 @@ func AsynqServeMux() *asynq.ServeMux {
 	onceServeMux.Do(func() {
 		serveMux = asynq.NewServeMux()
 		serveMux.Use(loggingMiddleware)
-		serveMux.HandleFunc(TaskEmailDelivery, HandleEmailDeliveryTask)
-		serveMux.HandleFunc(TaskReportAdd, HandleReportAddTask)
-		serveMux.HandleFunc(TaskPurgeCachePattern, HandlePurgeCachePatternTask)
+		serveMux.HandleFunc(cache.Key(TaskEmailDelivery), HandleEmailDeliveryTask)
+		serveMux.HandleFunc(cache.Key(TaskReportAdd), HandleReportAddTask)
+		serveMux.HandleFunc(cache.Key(TaskPurgeCachePattern), HandlePurgeCachePatternTask)
 	})
 
 	return serveMux
@@ -101,13 +101,13 @@ func AsynqPeriodicTaskManager() *asynq.PeriodicTaskManager {
 func loggingMiddleware(h asynq.Handler) asynq.Handler {
 	return asynq.HandlerFunc(func(ctx context.Context, t *asynq.Task) error {
 		start := time.Now()
-		slog.Info("Start processing task", slog.String("type", t.Type()))
+		slog.Info("Start processing task", slog.String("type", cache.RemoveKey(t.Type())))
 
 		if err := h.ProcessTask(ctx, t); err != nil {
 			sentry.CaptureException(err)
 			slog.Error(
 				"Could not process task",
-				slog.String("type", t.Type()),
+				slog.String("type", cache.Key(t.Type())),
 				slog.String("payload", string(t.Payload())),
 				slog.Any("error", err),
 			)
@@ -116,7 +116,7 @@ func loggingMiddleware(h asynq.Handler) asynq.Handler {
 
 		slog.Info(
 			"Finished processing task",
-			slog.String("type", t.Type()),
+			slog.String("type", cache.RemoveKey(t.Type())),
 			slog.Duration("duration", time.Since(start)),
 		)
 		return nil


### PR DESCRIPTION
Prefixes are only meant for internal use.

Implemented in #160 